### PR TITLE
Improved stats page

### DIFF
--- a/csharp-ef-webapi/Controllers/FantasyController.cs
+++ b/csharp-ef-webapi/Controllers/FantasyController.cs
@@ -46,6 +46,39 @@ namespace csharp_ef_webapi.Controllers
             return Ok(playerTotals);
         }
 
+        // // GET: api/fantasy/players/5/match/metadata
+        // [HttpGet("players/{leagueId}/match/metadata")]
+        // public async Task<ActionResult<List<GcMatchMetadata>>> GetFantasyLeagueMatchMetadata(int fantasyLeagueId)
+        // {
+        //     var matches = await _service.GetFantasyLeagueMetadataAsync(fantasyLeagueId);
+
+        //     if (matches == null || matches.Count() == 0)
+        //     {
+        //         return NotFound();
+        //     }
+
+        //     // Order matches so most recent show up first, we'll typically want to get highlights from the most recent
+        //     matches = matches.OrderByDescending(m => m.MatchId);
+
+        //     return Ok(matches);
+        // }
+
+        // GET: api/fantasy/league/5/metadata
+        [HttpGet("league/{fantasyLeagueId}/metadata")]
+        public async Task<ActionResult<List<MetadataSummary>>> GetFantasyLeagueMatchMetadata(int fantasyLeagueId)
+        {
+            var matchSummary = await _service.AggregateMetadataAsync(fantasyLeagueId);
+
+            if (matchSummary == null || matchSummary.Count() == 0)
+            {
+                return NotFound();
+            }
+
+            matchSummary = matchSummary.OrderBy(m => m.Player.DotaAccount.Name);
+
+            return Ok(matchSummary);
+        }
+
         // GET: api/fantasy/players/5/top10
         [Authorize]
         [HttpGet("players/{leagueId}/top10")]

--- a/csharp-ef-webapi/Data/AghanimsWagerContext.cs
+++ b/csharp-ef-webapi/Data/AghanimsWagerContext.cs
@@ -168,10 +168,26 @@ public class AghanimsFantasyContext : DbContext
             .WithOne()
             .OnDelete(DeleteBehavior.Cascade);
 
+        modelBuilder.Entity<GcMatchMetadata>()
+            .Navigation(md => md.Teams)
+            .AutoInclude();
+
+        modelBuilder.Entity<GcMatchMetadata>()
+            .Navigation(md => md.MatchTips)
+            .AutoInclude();
+
+        modelBuilder.Entity<GcMatchMetadata>()
+            .Navigation(md => md.MatchDetail)
+            .AutoInclude();
+
         modelBuilder.Entity<GcMatchMetadataTeam>()
             .HasMany(t => t.Players)
             .WithOne()
             .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<GcMatchMetadataTeam>()
+            .Navigation(mdt => mdt.Players)
+            .AutoInclude();
 
         modelBuilder.Entity<GcMatchMetadataPlayer>()
             .HasMany(t => t.Items)
@@ -182,6 +198,14 @@ public class AghanimsFantasyContext : DbContext
             .HasMany(t => t.Kills)
             .WithOne()
             .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<GcMatchMetadataPlayer>()
+            .Navigation(mdp => mdp.Items)
+            .AutoInclude();
+
+        modelBuilder.Entity<GcMatchMetadataPlayer>()
+            .Navigation(mdp => mdp.Kills)
+            .AutoInclude();
 
         #endregion
     }

--- a/csharp-ef-webapi/Data/AghanimsWagerContext.cs
+++ b/csharp-ef-webapi/Data/AghanimsWagerContext.cs
@@ -199,14 +199,6 @@ public class AghanimsFantasyContext : DbContext
             .WithOne()
             .OnDelete(DeleteBehavior.Cascade);
 
-        modelBuilder.Entity<GcMatchMetadataPlayer>()
-            .Navigation(mdp => mdp.Items)
-            .AutoInclude();
-
-        modelBuilder.Entity<GcMatchMetadataPlayer>()
-            .Navigation(mdp => mdp.Kills)
-            .AutoInclude();
-
         #endregion
     }
 

--- a/csharp-ef-webapi/Data/FantasyRepository.cs
+++ b/csharp-ef-webapi/Data/FantasyRepository.cs
@@ -1,5 +1,9 @@
+using System.Text.RegularExpressions;
 using csharp_ef_webapi.Models;
+using Microsoft.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using SteamKit2;
 
 namespace csharp_ef_webapi.Data;
 
@@ -287,7 +291,87 @@ public class FantasyRepository : IFantasyRepository
                       })
                       .OrderByDescending(fdp => fdp.DraftTotalFantasyPoints)
                       .ToList();
+    }
 
+    public async Task<IEnumerable<MetadataSummary>> AggregateMetadataAsync(int FantasyLeagueId)
+    {
+        _logger.LogInformation($"Fetching Aggregate Metadata for Fantasy League Id: {FantasyLeagueId}");
+
+        var metadataQuery = QueryFantasyLeagueMatchDetails(FantasyLeagueId)
+                .Where(md => md.MatchMetadata != null)
+                //Matchdetail joins
+                .SelectMany(mm => mm.Players,
+                    (left, right) => new { MatchDetail = left, MatchDetailPlayer = right }
+                )
+                //Metadata joins
+                .SelectMany(mm => mm.MatchDetail.MatchMetadata.Teams
+                    .SelectMany(mmt => mmt.Players)
+                    .Where(mmp => mmp.PlayerSlot == mm.MatchDetailPlayer.PlayerSlot),
+                    (left, right) => new { MatchDetailPlayer = left.MatchDetailPlayer, MatchMetadataPlayer = right }
+                )
+                .SelectMany(mm => _dbContext.FantasyPlayers
+                    .Where(fp => fp.FantasyLeagueId == FantasyLeagueId && fp.DotaAccountId == mm.MatchDetailPlayer.AccountId),
+                    (left, right) => new { MatchMetadataPlayer = left.MatchMetadataPlayer, MatchDetailPlayer = left.MatchDetailPlayer, FantasyPlayer = right }
+                )
+                .Where(fpm => fpm.MatchMetadataPlayer.PlayerSlot == fpm.MatchDetailPlayer.PlayerSlot)
+                .Distinct()
+                .GroupBy(fpm => fpm.FantasyPlayer);
+
+        _logger.LogInformation($"Fantasy Metadata Query: {metadataQuery.ToQueryString()}");
+
+        var metadataQueryList = await metadataQuery.ToListAsync();
+
+        // When we do the select to new MetadataSummary before resolving the group list it destroys the includes, not sure why
+
+        var aggregateMetadataQuery = metadataQueryList
+                .Select(
+                    final => new MetadataSummary
+                    {
+                        Player = final.Key,
+                        MatchDetailsPlayers = new MatchDetailsPlayer
+                        {
+                            Kills = final.Sum(result => result.MatchDetailPlayer.Kills),
+                            Deaths = final.Sum(result => result.MatchDetailPlayer.Deaths),
+                            Assists = final.Sum(result => result.MatchDetailPlayer.Assists),
+                            LastHits = final.Sum(result => result.MatchDetailPlayer.LastHits),
+                            Denies = final.Sum(result => result.MatchDetailPlayer.Denies),
+                            GoldPerMin = (int?)final.Average(result => result.MatchDetailPlayer.GoldPerMin),
+                            XpPerMin = (int?)final.Average(result => result.MatchDetailPlayer.XpPerMin),
+                            Networth = final.Sum(result => result.MatchDetailPlayer.Networth),
+                            HeroDamage = final.Sum(result => result.MatchDetailPlayer.HeroDamage),
+                            TowerDamage = final.Sum(result => result.MatchDetailPlayer.TowerDamage),
+                            HeroHealing = final.Sum(result => result.MatchDetailPlayer.HeroHealing),
+                            Gold = final.Sum(result => result.MatchDetailPlayer.Gold),
+                            ScaledHeroDamage = final.Sum(result => result.MatchDetailPlayer.ScaledHeroDamage),
+                            ScaledTowerDamage = final.Sum(result => result.MatchDetailPlayer.ScaledTowerDamage),
+                            ScaledHeroHealing = final.Sum(result => result.MatchDetailPlayer.ScaledHeroHealing)
+                        },
+                        MetadataPlayer = new GcMatchMetadataPlayer
+                        {
+                            WinStreak = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.WinStreak),
+                            BestWinStreak = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.BestWinStreak),
+                            FightScore = final.Sum(result => result.MatchMetadataPlayer.FightScore),
+                            FarmScore = final.Sum(result => result.MatchMetadataPlayer.FarmScore),
+                            SupportScore = final.Sum(result => result.MatchMetadataPlayer.SupportScore),
+                            PushScore = final.Sum(result => result.MatchMetadataPlayer.PushScore),
+                            HeroXp = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.HeroXp),
+                            CampsStacked = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.CampsStacked),
+                            Rampages = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.Rampages),
+                            TripleKills = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.TripleKills),
+                            AegisSnatched = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.AegisSnatched),
+                            RapiersPurchased = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.RapiersPurchased),
+                            CouriersKilled = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.CouriersKilled),
+                            NetworthRank = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.NetworthRank),
+                            SupportGoldSpent = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.SupportGoldSpent),
+                            ObserverWardsPlaced = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.ObserverWardsPlaced),
+                            SentryWardsPlaced = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.SentryWardsPlaced),
+                            WardsDewarded = (uint)final.Sum(result => (int)result.MatchMetadataPlayer.WardsDewarded),
+                            StunDuration = final.Sum(result => result.MatchMetadataPlayer.StunDuration),
+                        }
+                    }
+                );
+
+        return aggregateMetadataQuery.ToList();
     }
 
     public async Task<DateTime> GetLeagueLockedDate(int FantasyLeagueId)
@@ -471,10 +555,6 @@ public class FantasyRepository : IFantasyRepository
         var leagueMetadataQuery = QueryLeagueMatchDetails(LeagueId)
             .Where(md => md.MatchMetadata != null)
             .Select(l => l.MatchMetadata ?? new GcMatchMetadata())
-            .Include(md => md.Teams)
-                .ThenInclude(mdt => mdt.Players)
-                .ThenInclude(mdp => mdp.Kills)
-            .Include(md => md.MatchTips)
             .OrderByDescending(md => md.MatchId);
 
         _logger.LogInformation($"Match Metadata SQL Query: {leagueMetadataQuery.ToQueryString()}");
@@ -489,10 +569,6 @@ public class FantasyRepository : IFantasyRepository
         var leagueMetadataQuery = QueryLeagueMatchDetails(LeagueId)
             .Where(md => md.MatchMetadata != null)
             .Select(l => l.MatchMetadata ?? new GcMatchMetadata())
-            .Include(md => md.Teams)
-                .ThenInclude(mdt => mdt.Players)
-                .ThenInclude(mdp => mdp.Kills)
-            .Include(md => md.MatchTips)
             .OrderByDescending(md => md.MatchId)
             .Skip(Skip)
             .Take(Take);
@@ -508,11 +584,7 @@ public class FantasyRepository : IFantasyRepository
 
         var fantasyLeagueMetadataQuery = QueryFantasyLeagueMatchDetails(FantasyLeagueId)
             .Where(md => md.MatchMetadata != null)
-            .Select(l => l.MatchMetadata ?? new GcMatchMetadata())
-            .Include(md => md.Teams)
-                .ThenInclude(mdt => mdt.Players)
-                .ThenInclude(mdp => mdp.Kills)
-            .Include(md => md.MatchTips)
+            .Select(l => l.MatchMetadata)
             .OrderByDescending(md => md.MatchId);
 
         _logger.LogInformation($"Match Metadata SQL Query: {fantasyLeagueMetadataQuery.ToQueryString()}");
@@ -527,10 +599,6 @@ public class FantasyRepository : IFantasyRepository
         var fantasyLeagueMetadataQuery = QueryFantasyLeagueMatchDetails(FantasyLeagueId)
             .Where(md => md.MatchMetadata != null)
             .Select(md => md.MatchMetadata ?? new GcMatchMetadata()) // This should never be null but using it to suppress warning
-            .Include(md => md.Teams)
-                .ThenInclude(mdt => mdt.Players)
-                .ThenInclude(mdp => mdp.Kills)
-            .Include(md => md.MatchTips)
             .OrderByDescending(md => md.MatchId)
             .Skip(Skip)
             .Take(Take);
@@ -545,11 +613,7 @@ public class FantasyRepository : IFantasyRepository
         _logger.LogInformation($"Getting Match Metadata for Match: {MatchId}");
 
         var matchMetadataQuery = _dbContext.GcMatchMetadata
-                .Where(md => md.MatchId == MatchId)
-                .Include(md => md.Teams)
-                    .ThenInclude(mdt => mdt.Players)
-                    .ThenInclude(mdp => mdp.Kills)
-                .Include(md => md.MatchTips);
+                .Where(md => md.MatchId == MatchId);
 
         _logger.LogInformation($"Match Metadata Query: {matchMetadataQuery.ToQueryString()}");
 
@@ -617,7 +681,7 @@ public class FantasyRepository : IFantasyRepository
     public async Task<IEnumerable<Hero>> GetHeroesAsync()
     {
         _logger.LogInformation($"Getting Heroes loaded into DB");
-        
+
         return await _dbContext.Heroes.ToListAsync();
     }
 

--- a/csharp-ef-webapi/Models/DotaGameCoordinator/GcMatchMetadata.cs
+++ b/csharp-ef-webapi/Models/DotaGameCoordinator/GcMatchMetadata.cs
@@ -12,7 +12,7 @@ public class GcMatchMetadata
     public long Id { get; set; }
     [Column("match_id")]
     public long MatchId { get; set; }
-    public MatchDetail MatchDetail { get; set; } = new MatchDetail();
+    public MatchDetail MatchDetail { get; set; } = null!;
     [Column("lobby_id")]
     public ulong LobbyId { get; set; }
     [Column("report_until_time")]

--- a/csharp-ef-webapi/Models/DotaWebApi/MatchDetail.cs
+++ b/csharp-ef-webapi/Models/DotaWebApi/MatchDetail.cs
@@ -77,7 +77,7 @@ public class MatchDetail
     [Column("league_id")]
     [JsonProperty("leagueid")]
     public int LeagueId { get; set; }
-    public League League { get; set; } = new League();
+    public League League { get; set; } = null!;
 
     [Column("game_mode")]
     [JsonProperty("game_mode")]

--- a/csharp-ef-webapi/Models/ViewModels/MetadataSummary.cs
+++ b/csharp-ef-webapi/Models/ViewModels/MetadataSummary.cs
@@ -1,0 +1,46 @@
+namespace csharp_ef_webapi.Models;
+
+// This is a view model and isn't saved in the db (in case we change the scoring)
+public class MetadataSummary
+{
+    public FantasyPlayer Player { get; set; } = null!;
+    public MatchDetailsPlayer MatchDetailsPlayers { get; set; } = null!;
+    public GcMatchMetadataPlayer MetadataPlayer { get; set; } = null!;
+    // Match Details
+    public int? Kills { get { return MatchDetailsPlayers.Kills; } }
+    public int? Deaths { get { return MatchDetailsPlayers.Deaths; } }
+    public int? Assists { get { return MatchDetailsPlayers.Assists; } }
+    public int? LastHits { get { return MatchDetailsPlayers.LastHits; } }
+    public int? Denies { get { return MatchDetailsPlayers.Denies; } }
+    public int? GoldPerMin { get { return MatchDetailsPlayers.GoldPerMin; } }
+    public int? XpPerMin { get { return MatchDetailsPlayers.XpPerMin; } }
+    public long? Networth { get { return MatchDetailsPlayers.Networth; } }
+    public int? HeroDamage { get { return MatchDetailsPlayers.HeroDamage; } }
+    public int? TowerDamage { get { return MatchDetailsPlayers.TowerDamage; } }
+    public int? HeroHealing { get { return MatchDetailsPlayers.HeroHealing; } }
+    public int? Gold { get { return MatchDetailsPlayers.Gold; } }
+    public int? ScaledHeroDamage { get { return MatchDetailsPlayers.ScaledHeroDamage; } }
+    public int? ScaledTowerDamage { get { return MatchDetailsPlayers.ScaledTowerDamage; } }
+    public int? ScaledHeroHealing { get { return MatchDetailsPlayers.ScaledHeroHealing; } }
+
+    // Match Metadata
+    public uint WinStreak { get { return MetadataPlayer.WinStreak; } }
+    public uint BestWinStreak { get { return MetadataPlayer.BestWinStreak; } }
+    public float FightScore { get { return MetadataPlayer.FightScore; } }
+    public float FarmScore { get { return MetadataPlayer.FarmScore; } }
+    public float SupportScore { get { return MetadataPlayer.SupportScore; } }
+    public float PushScore { get { return MetadataPlayer.PushScore; } }
+    public uint HeroXp { get { return MetadataPlayer.HeroXp; } }
+    public uint CampsStacked { get { return MetadataPlayer.CampsStacked; } }
+    public uint Rampages { get { return MetadataPlayer.Rampages; } }
+    public uint TripleKills { get { return MetadataPlayer.TripleKills; } }
+    public uint AegisSnatched { get { return MetadataPlayer.AegisSnatched; } }
+    public uint RapiersPurchased { get { return MetadataPlayer.RapiersPurchased; } }
+    public uint CouriersKilled { get { return MetadataPlayer.CouriersKilled; } }
+    public uint NetworthRank { get { return MetadataPlayer.NetworthRank; } }
+    public uint SupportGoldSpent { get { return MetadataPlayer.SupportGoldSpent; } }
+    public uint ObserverWardsPlaced { get { return MetadataPlayer.ObserverWardsPlaced; } }
+    public uint SentryWardsPlaced { get { return MetadataPlayer.SentryWardsPlaced; } }
+    public uint WardsDewarded { get { return MetadataPlayer.WardsDewarded; } }
+    public float StunDuration { get { return MetadataPlayer.StunDuration; } }
+}

--- a/csharp-ef-webapi/Services/DotaWebApi/Contexts/MatchDetailsContext.cs
+++ b/csharp-ef-webapi/Services/DotaWebApi/Contexts/MatchDetailsContext.cs
@@ -37,7 +37,6 @@ internal class MatchDetailsContext : DotaOperationContext
             // Find all the match histories without match detail rows and add tasks to fetch them all
             ImmutableSortedSet<long> knownMatchHistories = _dbContext.MatchHistory.Select(x => x.MatchId).ToImmutableSortedSet();
             ImmutableSortedSet<long> knownMatchDetails = _dbContext.MatchDetails.Select(x => x.MatchId).ToImmutableSortedSet();
-            List<League> allLeagues = await _dbContext.Leagues.ToListAsync();
 
             List<long> matchesWithoutDetails = knownMatchHistories.Except(knownMatchDetails).Take(50).ToList();
 
@@ -67,8 +66,7 @@ internal class MatchDetailsContext : DotaOperationContext
                 {
                     if (!knownMatchDetails.Contains(matchDetail.MatchId))
                     {
-                        matchDetail.League = allLeagues.FirstOrDefault(l => l.Id == matchDetail.LeagueId) ?? 
-                            throw new Exception("MatchDetailsContext - Match belongs to unknown League");
+
                         // Set PicksBans Match IDs since it's not in json
                         foreach (MatchDetailsPicksBans picksBans in matchDetail.PicksBans)
                         {

--- a/csharp-ef-webapi/Services/DotaWebApi/Contexts/MatchMetadataContext.cs
+++ b/csharp-ef-webapi/Services/DotaWebApi/Contexts/MatchMetadataContext.cs
@@ -42,10 +42,6 @@ internal class MatchMetadataContext : DotaOperationContext
                 .Take(50)
                 .ToList();
 
-            List<MatchDetail> allMatchDetails = await _dbContext.MatchDetails
-                .Where(md => matchesWithoutDetails.Select(mwd => (long)mwd.match_id).Contains(md.MatchId))
-                .ToListAsync();
-
             if (matchesWithoutDetails.Count() > 0)
             {
                 var length = matchesWithoutDetails.Count;
@@ -70,8 +66,6 @@ internal class MatchMetadataContext : DotaOperationContext
 
                 foreach (GcMatchMetadata matchDetail in _matches)
                 {
-                    matchDetail.MatchDetail = allMatchDetails.FirstOrDefault(md => md.MatchId == matchDetail.MatchId) ?? 
-                            throw new Exception("MatchMetadataContext - Match belongs to unknown MatchDetail");
                     _dbContext.GcMatchMetadata.Add(matchDetail);
                 }
                 await _dbContext.SaveChangesAsync();

--- a/frontend/quasar-web-app/src/layouts/MainLayout.vue
+++ b/frontend/quasar-web-app/src/layouts/MainLayout.vue
@@ -6,13 +6,13 @@
 
         <q-toolbar-title v-if="isWideScreen" class="title">
           <q-avatar>
-            <img src="~assets/BannerAvatar.png">
+            <q-img src="~assets/BannerAvatar.png" height="38px" width="38px"/>
           </q-avatar>
           Aghanim's Fantasy
         </q-toolbar-title>
         <q-toolbar-title v-else class="title">
           <q-avatar>
-            <img src="~assets/BannerAvatar.png">
+            <q-img src="~assets/BannerAvatar.png" height="38px" width="38px"/>
           </q-avatar>
         </q-toolbar-title>
 

--- a/frontend/quasar-web-app/src/pages/FantasyStatsPage.vue
+++ b/frontend/quasar-web-app/src/pages/FantasyStatsPage.vue
@@ -1,8 +1,274 @@
 <template>
     <div class="flex-container">
+        <div class="row" style="max-width:400px">
+            <q-tabs v-model="tab" class="text-grey-5" active-color="grey-1" indicator-color="red-13" narrow-indicator>
+                <q-tab name="fantasy" label="Fantasy" />
+                <q-tab name="league" label="League" />
+            </q-tabs>
+        </div>
+        <q-separator />
         <div class="row">
-            <q-table class="fantasy-stats-table" title="Fantasy Player Stats" :columns="columns"
-                :rows="playerFantasyStatsIndexed" virtual-scroll :rows-per-page-options="[0]" />
+            <q-tab-panels v-model="tab" animated style="width:100%;max-width:1800px">
+                <q-tab-panel name="fantasy" style="padding: 0px">
+                    <div class="row">
+                        <div style="width:55%; max-width:300px; padding:10px">
+                            <q-input v-model="fantasyFilter" debounce="500" color="red-13" label="Search" dense outlined>
+                                <template v-slot:append>
+                                    <q-icon name="search" />
+                                </template>
+                            </q-input>
+                        </div>
+                        <q-space />
+                        <q-tabs v-if="!this.isDesktop" v-model="fantasyTab" dense class="text-grey-5" active-color="grey-1"
+                            indicator-color="red-13" style="width:45%;margin-bottom:5px">
+                            <q-tab name="kda" label="K/D/A" />
+                            <q-tab name="farm" label="Farm" />
+                        </q-tabs>
+                    </div>
+                    <div class="row">
+                        <q-table class="fantasy-stats-table" dense :columns="displayedFantasyColumns"
+                            :rows="playerFantasyStatsIndexed" virtual-scroll :rows-per-page-options="[0]" style="width:100%"
+                            separator="vertical">
+                            <template v-slot:body-cell-fantasyPlayerRank="props">
+                                <q-td :props="props" style="padding:0" auto-width>
+                                    <div>
+                                        {{ props.value }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-fantasyPlayer="props">
+                                <q-td :props="props">
+                                    <div class="row">
+                                        <div v-if="this.isDesktop" class="col" style="max-width:65px">
+                                            <q-img height="60px" width="60px" :src="props.value.playerPicture" />
+                                        </div>
+                                        <div class="col">
+                                            <div style="white-space:normal">
+                                                <b>{{ props.value.playerName }}</b>
+                                                <br>
+                                                {{ props.value.teamName }}
+                                            </div>
+                                            <div class="text-grey-6">
+                                                {{ props.value.matches }} games
+                                            </div>
+                                        </div>
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalKills="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        <b>{{ props.value.killPoints }}</b>
+                                        <br>
+                                        ({{ props.value.kills }})
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalDeaths="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        <b>{{ props.value.deathPoints }}</b>
+                                        <br>
+                                        ({{ props.value.deaths }})
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalAssists="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        <b>{{ props.value.assistPoints }}</b>
+                                        <br>
+                                        ({{ props.value.assists }})
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalLastHits="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        <b>{{ props.value.lastHitsPoints }}</b>
+                                        <br>
+                                        ({{ props.value.lastHits }})
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalGoldPerMin="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        <b>{{ props.value.goldPerMinPoints }}</b>
+                                        <br>
+                                        ({{ props.value.goldPerMin }})
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalXpPerMin="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        <b>{{ props.value.xpPerMinPoints }}</b>
+                                        <br>
+                                        ({{ props.value.xpPerMin }})
+                                    </div>
+                                </q-td>
+                            </template>
+                        </q-table>
+                    </div>
+                </q-tab-panel>
+                <q-tab-panel name="league" style="padding: 0px">
+                    <div class="row">
+                        <div style="width:55%; max-width:300px; padding:10px">
+                            <q-input v-model="leagueFilter" debounce="500" color="red-13" label="Search" dense outlined>
+                                <template v-slot:append>
+                                    <q-icon name="search" />
+                                </template>
+                            </q-input>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <q-tabs v-if="!this.isDesktop" v-model="leagueTab" dense class="text-grey-5" active-color="grey-1"
+                            indicator-color="red-13" style="margin-bottom:5px">
+                            <q-tab name="kda" label="K/D/A" />
+                            <q-tab name="farm" label="Farm" />
+                            <q-tab name="support" label="Supp." />
+                            <q-tab name="damageHealing" label="Dmg/Heal" />
+                        </q-tabs>
+                    </div>
+                    <div class="row">
+                        <q-table class="league-stats-table" dense :columns="displayedLeagueColumns"
+                            :rows="fantasyLeagueMetadataStatsIndexed" virtual-scroll :rows-per-page-options="[0]"
+                            separator="vertical" style="width:100%">
+                            <template v-slot:body-cell-leaguePlayer="props">
+                                <q-td :props="props">
+                                    <div class="row">
+                                        <div v-if="this.isDesktop" class="col" style="max-width:65px">
+                                            <q-img height="60px" width="60px" :src="props.value.playerPicture" />
+                                        </div>
+                                        <div class="col">
+                                            <div style="white-space:normal">
+                                                <b>{{ props.value.playerName }}</b>
+                                                <br>
+                                                {{ props.value.teamName }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalKills="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.kills }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalDeaths="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.deaths }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalAssists="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.assists }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalLastHits="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.lastHits }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalDenies="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.denies }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalGoldPerMin="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.goldPerMin }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalXpPerMin="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.xpPerMin }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalSupportGoldSpent="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        <span :style="{fontSize: isDesktop ? '1em' : '0.85em'}">
+                                            {{ props.value.supportGoldSpent.toLocaleString() }}
+                                        </span>
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalObsPlaced="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.observerWardsPlaced }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalSentriesPlaced="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.sentryWardsPlaced }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalWardsDewarded="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.wardsDewarded }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalCampsStacked="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.campsStacked }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalHeroDamage="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.heroDamage.toLocaleString() }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalTowerDamage="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.towerDamage.toLocaleString() }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalHeroHealing="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.heroHealing.toLocaleString() }}
+                                    </div>
+                                </q-td>
+                            </template>
+                            <template v-slot:body-cell-totalStunDuration="props">
+                                <q-td :props="props">
+                                    <div style="white-space:normal">
+                                        {{ props.value.stunDuration.toFixed(1).toLocaleString() }}
+                                    </div>
+                                </q-td>
+                            </template>
+                        </q-table>
+                    </div>
+                </q-tab-panel>
+            </q-tab-panels>
         </div>
     </div>
 </template>
@@ -19,127 +285,404 @@ export default {
         const authStore = useAuthStore();
         const leagueStore = useLeagueStore();
 
+        const tab = ref('fantasy');
+        const fantasyTab = ref('kda');
+        const fantasyFilter = ref('');
+        const leagueTab = ref('kda');
+        const leagueFilter = ref('');
+        const isDesktop = ref(window.outerWidth >= 600);
+
+        const showFantasyFilters = ref(false);
+
         const playerFantasyStats = ref([]);
-        const columns = [
+        const fantasyLeagueMetadataStats = ref([]);
+        const commonFantasyColumns = [
             {
-                name: 'fantasyPlayerPosition',
-                label: '#',
-                align: 'left',
+                name: 'fantasyPlayerRank',
+                label: '',
+                align: 'center',
                 field: row => row.position,
-                format: val => `${val}`,
-                sortable: true
+                style: 'width: 15px',
+                sortable: false
             },
             {
                 name: 'fantasyPlayer',
-                label: 'Player',
+                label: 'Player/Team/Games',
                 align: 'left',
-                field: row => row.fantasyPlayer.dotaAccount.name,
-                format: val => `${val}`,
-                style: 'width: 200px; max-width: 200px',
-                sortable: true
-            },
-            {
-                name: 'fantasyPlayerTeam',
-                label: 'Team',
-                align: 'left',
-                field: row => row.fantasyPlayer.team.name,
-                format: val => `${val}`,
-                style: 'width: 150px; max-width: 150px',
-                sortable: true
-            },
-            {
-                name: 'totalMatches',
-                label: 'Matches',
-                align: 'right',
-                field: row => row.totalMatches,
-                sortable: true
-            },
-            {
-                name: 'totalKills',
-                label: 'Kills (pts)',
-                align: 'left',
-                field: row => row,
-                format: val => val.totalKills + ` (${val.totalKillsPoints.toFixed(1)})`,
-                sortable: true,
-                sort: (a, b) => a.totalKills - b.totalKills
-            },
-            {
-                name: 'totalDeaths',
-                label: 'Deaths (pts)',
-                align: 'left',
-                field: row => row,
-                format: val => val.totalDeaths + ` (${val.totalDeathsPoints.toFixed(1)})`,
-                sortable: true,
-                sort: (a, b) => a.totalDeaths - b.totalDeaths
-            },
-            {
-                name: 'totalAssists',
-                label: 'Assists (pts)',
-                align: 'left',
-                field: row => row,
-                format: val => val.totalAssists + ` (${val.totalAssistsPoints.toFixed(1)})`,
-                sortable: true,
-                sort: (a, b) => a.totalAssists - b.totalAssists
-            },
-            {
-                name: 'totalLastHits',
-                label: 'LastHits (pts)',
-                align: 'left',
-                field: row => row,
-                format: val => val.totalLastHits.toLocaleString() + ` (${val.totalLastHitsPoints.toFixed(1).toLocaleString()})`,
-                sortable: true,
-                sort: (a, b) => a.totalLastHits - b.totalLastHits
-            },
-            {
-                name: 'totalGoldPerMin',
-                label: 'GoldPerMin (pts)',
-                align: 'left',
-                field: row => row,
-                format: val => val.avgGoldPerMin.toLocaleString() + ` (${val.totalGoldPerMinPoints.toFixed(1).toLocaleString()})`,
-                sortable: true,
-                sort: (a, b) => a.avgGoldPerMin - b.avgGoldPerMin
-            },
-            {
-                name: 'totalXpPerMin',
-                label: 'XpPerMin (pts)',
-                align: 'left',
-                field: row => row,
-                format: val => val.avgXpPerMin.toLocaleString() + ` (${val.totalXpPerMinPoints.toFixed(1).toLocaleString()})`,
-                sortable: true,
-                sort: (a, b) => a.avgXpPerMin - b.avgXpPerMin
+                field: row => {
+                    return {
+                        playerName: row.fantasyPlayer.dotaAccount.name,
+                        playerPicture: row.fantasyPlayer.dotaAccount.steamProfilePicture,
+                        teamName: row.fantasyPlayer.team.name,
+                        matches: row.totalMatches
+                    };
+                },
+                style: 'width: 400px',
+                sortable: false
             },
             {
                 name: 'totalPoints',
-                label: 'Total Points',
-                align: 'right',
-                field: row => row.totalMatchFantasyPoints,
+                label: isDesktop.value ? 'Total Points' : 'Pts',
+                align: 'left',
+                field: row => row.totalMatchFantasyPoints.toFixed(1),
                 format: val => `${val.toLocaleString()}`,
                 headerStyle: 'font-weight: bold',
                 style: 'font-weight: bold',
                 sortable: true
             },
         ];
+        const kdaFantasyColumns = [
+            {
+                name: 'totalKills',
+                label: isDesktop.value ? 'Kills' : 'K',
+                align: 'left',
+                field: row => {
+                    return {
+                        kills: row.totalKills,
+                        killPoints: row.totalKillsPoints.toFixed(1)
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.killPoints - b.killPoints
+            },
+            {
+                name: 'totalDeaths',
+                label: isDesktop.value ? 'Deaths' : 'D',
+                align: 'left',
+                field: row => {
+                    return {
+                        deaths: row.totalDeaths,
+                        deathPoints: row.totalDeathsPoints.toFixed(1)
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.deathPoints - b.deathPoints
+            },
+            {
+                name: 'totalAssists',
+                label: isDesktop.value ? 'Assists' : 'A',
+                align: 'left',
+                field: row => {
+                    return {
+                        assists: row.totalAssists,
+                        assistPoints: row.totalAssistsPoints.toFixed(1)
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.assistPoints - b.assistPoints
+            },
+        ];
+        const farmFantasyColumns = [
+            {
+                name: 'totalLastHits',
+                label: isDesktop.value ? 'Last Hits' : 'LH',
+                align: 'left',
+                field: row => {
+                    return {
+                        lastHits: row.totalLastHits.toLocaleString(),
+                        lastHitsPoints: row.totalLastHitsPoints.toFixed(1).toLocaleString()
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.lastHitsPoints - b.lastHitsPoints
+            },
+            {
+                name: 'totalGoldPerMin',
+                label: isDesktop.value ? 'Average Gold Per Min' : 'G',
+                align: 'left',
+                field: row => {
+                    return {
+                        goldPerMin: row.avgGoldPerMin.toFixed(0).toLocaleString(),
+                        goldPerMinPoints: row.totalGoldPerMinPoints.toFixed(1).toLocaleString()
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.goldPerMinPoints - b.goldPerMinPoints
+            },
+            {
+                name: 'totalXpPerMin',
+                label: isDesktop.value ? 'Average XP Per Min' : 'XP',
+                align: 'left',
+                field: row => {
+                    return {
+                        xpPerMin: row.avgXpPerMin.toFixed(0).toLocaleString(),
+                        xpPerMinPoints: row.totalXpPerMinPoints.toFixed(1).toLocaleString()
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.xpPerMinPoints - b.xpPerMinPoints
+            },
+        ];
+
+        const commonLeagueColumns = [
+            {
+                name: 'leaguePlayer',
+                label: 'Player/Team',
+                align: 'left',
+                field: row => {
+                    return {
+                        playerName: row.player.dotaAccount.name,
+                        playerPicture: row.player.dotaAccount.steamProfilePicture,
+                        teamName: row.player.team.name
+                    };
+                },
+                style: 'width: 400px',
+                sortable: true,
+                sort: (a, b) => {
+                    if (a.playerName > b.playerName) return 1;
+                    if (a.playerName < b.playerName) return -1;
+                }
+            },
+        ];
+        const kdaLeagueColumns = [
+            {
+                name: 'totalKills',
+                label: isDesktop.value ? 'Kills' : 'K',
+                align: 'left',
+                field: row => {
+                    return {
+                        kills: row.matchDetailsPlayers.kills,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.kills - b.kills
+            },
+            {
+                name: 'totalDeaths',
+                label: isDesktop.value ? 'Deaths' : 'D',
+                align: 'left',
+                field: row => {
+                    return {
+                        deaths: row.matchDetailsPlayers.deaths,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.deaths - b.deaths
+            },
+            {
+                name: 'totalAssists',
+                label: isDesktop.value ? 'Assists' : 'A',
+                align: 'left',
+                field: row => {
+                    return {
+                        assists: row.matchDetailsPlayers.assists,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.assists - b.assists
+            },
+        ];
+        const farmLeagueColumns = [
+            {
+                name: 'totalLastHits',
+                label: isDesktop.value ? 'Last Hits' : 'LH',
+                align: 'left',
+                field: row => {
+                    return {
+                        lastHits: row.matchDetailsPlayers.lastHits,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.lastHits - b.lastHits
+            },
+            {
+                name: 'totalDenies',
+                label: isDesktop.value ? 'Denies' : 'DN',
+                align: 'left',
+                field: row => {
+                    return {
+                        denies: row.matchDetailsPlayers.denies,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.denies - b.denies
+            },
+            {
+                name: 'totalGoldPerMin',
+                label: isDesktop.value ? 'Avg GPM' : 'G',
+                align: 'left',
+                field: row => {
+                    return {
+                        goldPerMin: row.matchDetailsPlayers.goldPerMin,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.goldPerMin - b.goldPerMin
+            },
+            {
+                name: 'totalXpPerMin',
+                label: isDesktop.value ? 'Avg XPM' : 'XP',
+                align: 'left',
+                field: row => {
+                    return {
+                        xpPerMin: row.matchDetailsPlayers.xpPerMin
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.xpPerMin - b.xpPerMin
+            },
+        ];
+        const supportLeagueColumns = [
+            {
+                name: 'totalSupportGoldSpent',
+                label: isDesktop.value ? 'Supp. Gold Spent' : 'SG',
+                align: 'left',
+                field: row => {
+                    return {
+                        supportGoldSpent: row.metadataPlayer?.supportGoldSpent ?? 0,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.supportGoldSpent - b.supportGoldSpent
+            },
+            {
+                name: 'totalObsPlaced',
+                label: isDesktop.value ? 'Obs Placed' : 'OB',
+                align: 'left',
+                field: row => {
+                    return {
+                        observerWardsPlaced: row.metadataPlayer?.observerWardsPlaced ?? 0,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.observerWardsPlaced - b.observerWardsPlaced
+            },
+            {
+                name: 'totalSentriesPlaced',
+                label: isDesktop.value ? 'Sentires Placed' : 'SN',
+                align: 'left',
+                field: row => {
+                    return {
+                        sentryWardsPlaced: row.metadataPlayer?.sentryWardsPlaced ?? 0,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.sentryWardsPlaced - b.sentryWardsPlaced
+            },
+            {
+                name: 'totalWardsDewarded',
+                label: isDesktop.value ? 'Dewards' : 'DW',
+                align: 'left',
+                field: row => {
+                    return {
+                        wardsDewarded: row.metadataPlayer?.wardsDewarded ?? 0
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.wardsDewarded - b.wardsDewarded
+            },
+            {
+                name: 'totalCampsStacked',
+                label: isDesktop.value ? 'Camps Stacked' : 'C',
+                align: 'left',
+                field: row => {
+                    return {
+                        campsStacked: row.metadataPlayer?.campsStacked ?? 0
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.campsStacked - b.campsStacked
+            },
+        ];
+        const damageHealingLeagueColumns = [
+            {
+                name: 'totalHeroDamage',
+                label: isDesktop.value ? 'Hero Dmg' : 'HD',
+                align: 'left',
+                field: row => {
+                    return {
+                        heroDamage: row.matchDetailsPlayers?.heroDamage ?? 0,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.heroDamage - b.heroDamage
+            },
+            {
+                name: 'totalTowerDamage',
+                label: isDesktop.value ? 'Tower Dmg' : 'TD',
+                align: 'left',
+                field: row => {
+                    return {
+                        towerDamage: row.matchDetailsPlayers?.towerDamage ?? 0,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.towerDamage - b.towerDamage
+            },
+            {
+                name: 'totalHeroHealing',
+                label: isDesktop.value ? 'Hero Healing' : 'HH',
+                align: 'left',
+                field: row => {
+                    return {
+                        heroHealing: row.matchDetailsPlayers?.heroHealing ?? 0,
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.sentryWardsPlaced - b.sentryWardsPlaced
+            },
+            {
+                name: 'totalStunDuration',
+                label: isDesktop.value ? 'Stun Dur.' : 'SD',
+                align: 'left',
+                field: row => {
+                    return {
+                        stunDuration: row.metadataPlayer?.stunDuration ?? 0
+                    };
+                },
+                sortable: true,
+                sort: (a, b) => a.stunDuration - b.stunDuration
+            },
+        ];
+
+        const selectedFantasyColumns = ref(commonFantasyColumns.map(column => column.name));
 
         onMounted(() => {
             if (leagueStore.selectedLeague) {
                 localApiService.getPlayerFantasyStats(leagueStore.selectedLeague.id)
-                                .then(result => playerFantasyStats.value = result);
-
+                    .then(result => playerFantasyStats.value = result);
+                localApiService.getFantasyLeagueMetadataStats(leagueStore.selectedLeague.id)
+                    .then(result => fantasyLeagueMetadataStats.value = result);
             }
         });
 
+        // Define a function to stringify nested objects recursively
+        const stringifyNested = (obj) => {
+            if (typeof obj !== 'object' || obj === null) {
+                return String(obj);
+            }
+            return Object.values(obj)
+                .map(val => stringifyNested(val))
+                .join(' ');
+        };
+
         const playerFantasyStatsIndexed = computed(() => {
-            return playerFantasyStats.value.map((player, index) => ({ 
-                ...player, 
-                position: index + 1 
-            }));
-        })
+            return playerFantasyStats.value
+                .map((player, index) => ({
+                    ...player,
+                    position: index + 1
+                })).filter(item =>
+                    Object.values(item).some(val => stringifyNested(val).toLowerCase().includes(fantasyFilter.value.toLowerCase())
+                    ));
+        });
+
+        const fantasyLeagueMetadataStatsIndexed = computed(() => {
+            return fantasyLeagueMetadataStats.value
+                .map((player, index) => ({
+                    ...player,
+                    position: index + 1
+                })).filter(item =>
+                    Object.values(item).some(val => stringifyNested(val).toLowerCase().includes(leagueFilter.value.toLowerCase())
+                    ));
+        });
 
         watch(() => leagueStore.selectedLeague, (newValue) => {
             if (newValue) {
                 if (leagueStore.selectedLeague) {
                     localApiService.getPlayerFantasyStats(leagueStore.selectedLeague.id)
-                                    .then(result => playerFantasyStats.value = result);
+                        .then(result => playerFantasyStats.value = result);
+                    localApiService.getFantasyLeagueMetadataStats(leagueStore.selectedLeague.id)
+                        .then(result => fantasyLeagueMetadataStats.value = result);
                 }
             }
         });
@@ -147,11 +690,65 @@ export default {
         return {
             authStore,
             leagueStore,
+            tab,
+            fantasyTab,
+            fantasyFilter,
+            leagueTab,
+            leagueFilter,
             playerFantasyStats,
             playerFantasyStatsIndexed,
-            columns
+            fantasyLeagueMetadataStats,
+            fantasyLeagueMetadataStatsIndexed,
+            selectedFantasyColumns,
+            commonFantasyColumns,
+            kdaFantasyColumns,
+            farmFantasyColumns,
+            commonLeagueColumns,
+            kdaLeagueColumns,
+            farmLeagueColumns,
+            supportLeagueColumns,
+            damageHealingLeagueColumns,
+            showFantasyFilters,
+            isDesktop
         }
-    }
+    },
+    computed: {
+        displayedFantasyColumns() {
+            if (this.isDesktop) {
+                return [...this.commonFantasyColumns, ...this.kdaFantasyColumns, ...this.farmFantasyColumns];
+            }
+            else {
+                switch (this.fantasyTab) {
+                    case 'kda':
+                        return [...this.commonFantasyColumns, ...this.kdaFantasyColumns];
+                    case 'farm':
+                        return [...this.commonFantasyColumns, ...this.farmFantasyColumns];
+                    default:
+                        return [...this.commonFantasyColumns];
+                }
+            }
+        },
+        displayedLeagueColumns() {
+            if (this.isDesktop) {
+                return [...this.commonLeagueColumns, ...this.kdaLeagueColumns, ...this.farmLeagueColumns, ...this.supportLeagueColumns, ...this.damageHealingLeagueColumns];
+            }
+            else {
+                switch (this.leagueTab) {
+                    case 'kda':
+                        return [...this.commonLeagueColumns, ...this.kdaLeagueColumns];
+                    case 'farm':
+                        return [...this.commonLeagueColumns, ...this.farmLeagueColumns];
+                    case 'support':
+                        return [...this.commonLeagueColumns, ...this.supportLeagueColumns];
+                    case 'damageHealing':
+                        return [...this.commonLeagueColumns, ...this.damageHealingLeagueColumns];
+                    default:
+                        return [...this.commonLeagueColumns];
+                }
+            }
+        }
+    },
+
 }
 </script>
   
@@ -180,23 +777,22 @@ export default {
   /* prevent scrolling behind sticky top row on focus */
   tbody
     /* height of all previous header rows */
-    scroll-margin-top: 48px
+    scroll-margin-top: 24px
 </style>
   <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
 .debug {
     border: 1px solid red;
-    padding: 10px;
 }
 
 thead th tr {
     position: sticky;
 }
 
-.fantasy-stats-table {
+/* .fantasy-stats-table {
     width: 1400px;
     height: 800px;
-}
+} */
 
 .left-fixed {
     flex: 0 0 300px;
@@ -206,7 +802,6 @@ thead th tr {
     display: flex;
     flex-flow: row wrap;
     max-width: 100%;
-    padding: 20px;
 }
 
 .flex-break {

--- a/frontend/quasar-web-app/src/services/localApiService.js
+++ b/frontend/quasar-web-app/src/services/localApiService.js
@@ -174,6 +174,23 @@ export const localApiService = {
                 throw error;
             });
     },
+    getFantasyLeagueMetadataStats(leagueId) {
+        return fetch(`${baseUrl}/fantasy/league/${leagueId}/metadata`)
+            .then(function (response) {
+                if (!response.ok) {
+                    throw response.status;
+                } else {
+                    return response.json();
+                }
+            }.bind(this))
+            .then(function (data) {
+                return data;
+            }.bind(this))
+            .catch(error => {
+                console.error('Error fetching data:', error);
+                throw error;
+            });
+    },
     getTopTenDrafts(leagueId) {
         return fetch(`${baseUrl}/fantasy/players/${leagueId}/top10`)
             .then(function (response) {


### PR DESCRIPTION
This is mostly frontend, but I had to clean up the aggregate metadata call. Realistically after seeing this run in prod I should probably pull the trigger now on switching things to SQL views that the c# just calls directly and maps to a view model.

- Fantasy call to get summary metadata for a fantasy league
- Tons of mobile work: League tab for metadata, tab based table to compress to mobile, toggles to a full table when on desktop.
- Fixed AutoInclude to avoid having to repeat them for Team/Account stuff on FantasyPlayer in particular