### PR TITLE
Fantasy league routing

### DIFF
--- a/frontend/vue3-web-app/package.json
+++ b/frontend/vue3-web-app/package.json
@@ -39,7 +39,7 @@
     "@vue/eslint-config-typescript": "^13.0.0",
     "@vue/test-utils": "^2.4.5",
     "@vue/tsconfig": "^0.5.1",
-    "cypress": "^13.7.2",
+    "cypress": "^13.15.2",
     "eslint": "^8.57.0",
     "eslint-plugin-cypress": "^2.15.1",
     "eslint-plugin-vue": "^9.23.0",

--- a/frontend/vue3-web-app/src/components/Fantasy/CreateDraft/CreateDraft.vue
+++ b/frontend/vue3-web-app/src/components/Fantasy/CreateDraft/CreateDraft.vue
@@ -38,11 +38,12 @@
         </div>
 
 
-        <div v-if="isDesktop" style="margin-top:120px;margin-right:450px;">
-            <PlayerPicksAvailable class="picks-available" />
+        <div v-if="isDesktop" style="margin-top:120px;margin-right:450px;min-height:620px;">
+            <PlayerPicksAvailable class="picks-available" :FantasyLeague="selectedFantasyLeague" />
         </div>
         <div v-else style="margin-top:120px;">
-            <PlayerPicksAvailable class="picks-available" @click="toggleDrawer" />
+            <PlayerPicksAvailable class="picks-available" :FantasyLeague="selectedFantasyLeague"
+                @click="toggleDrawer" />
         </div>
     </div>
 </template>

--- a/frontend/vue3-web-app/src/components/Fantasy/CreateDraft/PlayerStats.vue
+++ b/frontend/vue3-web-app/src/components/Fantasy/CreateDraft/PlayerStats.vue
@@ -41,7 +41,7 @@ import PlayerRadarChart from '@/components/Fantasy/PlayerStats/PlayerRadarChart.
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faDice } from '@fortawesome/free-solid-svg-icons';
 
-const { selectedPlayer, fantasyPlayersAvailable, setFantasyPlayer, disabledPlayer } = fantasyDraftState();
+const { selectedPlayer, fantasyPlayerPointsAvailable, setFantasyPlayer, disabledPlayer } = fantasyDraftState();
 
 const emit = defineEmits(['savePlayer']);
 
@@ -137,9 +137,9 @@ const draftPlayer = () => {
 }
 
 const randomPlayer = () => {
-    var availablePicks = fantasyPlayersAvailable.value.filter(pa => !disabledPlayer(pa))
+    var availablePicks = fantasyPlayerPointsAvailable.value.filter(pa => !disabledPlayer(pa.fantasyPlayer))
     var randomPick = availablePicks[(Math.floor(Math.random() * availablePicks.length))];
-    selectedPlayer.value = randomPick;
+    selectedPlayer.value = randomPick.fantasyPlayer;
 }
 
 </script>

--- a/frontend/vue3-web-app/src/components/Fantasy/DraftPickCard.vue
+++ b/frontend/vue3-web-app/src/components/Fantasy/DraftPickCard.vue
@@ -1,6 +1,30 @@
 <template>
   <div class="draft-card">
-    <v-card class="card-container">
+    <v-card v-if="props.size == 'small'" class="card-container">
+      <div class="card-title-small">
+        <v-card-title class="ma-0 pa-0" :style="{ 'font-size': isDesktop ? '0.9rem' : '0.7rem' }">
+          {{ props.fantasyPlayer?.dotaAccount?.name || '' }}
+        </v-card-title>
+      </div>
+      <div class="card-images">
+        <img class="player-image" :style="{ 'max-width': isDesktop ? '70px' : '60px' }" :src="getPlayerLogo()" />
+        <img class="team-image" :src="getTeamLogo()" />
+      </div>
+      <div class="draft-body-small">
+        <v-card-text class="pt-1 pl-2" style="min-height: 3rem;">
+          <div v-if="props.fantasyLeagueActive">
+            <span :style="{ 'font-size': '0.8rem', 'font-weight': 'bold' }">
+              {{ props.fantasyPoints?.toFixed(2) ?? 0 }}
+            </span>
+            <br />
+            <span :style="{ 'font-size': '0.8rem' }">
+              Fantasy Pts
+            </span>
+          </div>
+        </v-card-text>
+      </div>
+    </v-card>
+    <v-card v-else class="card-container">
       <div class="card-title">
         <v-card-title class="ma-0 pl-1 pa-0" :style="{ 'font-size': isDesktop ? '1.2rem' : '1rem' }">
           {{ props.fantasyPlayer?.dotaAccount?.name || '' }}
@@ -30,7 +54,6 @@
           </div>
         </v-card-text>
       </div>
-
     </v-card>
   </div>
 </template>
@@ -41,6 +64,10 @@ import { VCard, VCardTitle, VCardSubtitle, VCardText } from 'vuetify/components'
 import type { FantasyPlayer } from './fantasyDraft';
 
 const props = defineProps({
+  size: {
+    type: String,
+    required: false
+  },
   fantasyPlayer: {
     type: Object as PropType<FantasyPlayer>,
     required: false
@@ -49,6 +76,10 @@ const props = defineProps({
     type: Number,
     required: false
   },
+  fantasyLeagueActive: {
+    type: Boolean,
+    required: false
+  }
 })
 
 const isDesktop = ref(window.outerWidth >= 600);
@@ -95,6 +126,11 @@ const getTeamLogo = () => {
   background-color: var(--aghanims-fantasy-main-2);
 }
 
+.card-title-small {
+  background-color: var(--aghanims-fantasy-main-2);
+  font-family: 'Roboto', sans-serif;
+}
+
 .card-images {
   display: flex;
   justify-content: center;
@@ -106,6 +142,14 @@ const getTeamLogo = () => {
   border-top: 3px solid var(--aghanims-fantasy-main-2);
   height: 50%;
   text-align: start;
+}
+
+.draft-body-small {
+  background: linear-gradient(to bottom, var(--aghanims-fantasy-main-2), var(--aghanims-fantasy-blue-1));
+  border-top: 3px solid var(--aghanims-fantasy-main-2);
+  height: 50%;
+  text-align: start;
+  font-family: 'Roboto', sans-serif;
 }
 
 .draft-body-main {

--- a/frontend/vue3-web-app/src/components/Fantasy/FantasyNavbar.vue
+++ b/frontend/vue3-web-app/src/components/Fantasy/FantasyNavbar.vue
@@ -46,9 +46,12 @@ import { computed, onMounted, watch } from 'vue';
 import { useFantasyLeagueStore } from '@/stores/fantasyLeague';
 import { useAuthStore } from '@/stores/auth';
 import { VContainer, VRow, VCol, VSelect, VListItem, VIcon, VTab, VTabs } from 'vuetify/components'
+import { useRoute } from 'vue-router';
 
 const authStore = useAuthStore()
 const leagueStore = useFantasyLeagueStore()
+
+const route = useRoute();
 
 const leagueOptions = computed(() => {
   return leagueStore.activeLeagues.sort((a, b) => b.id - a.id)
@@ -63,17 +66,18 @@ const fantasyLeagueOptions = computed(() => {
 onMounted(() => {
   authStore.checkAuthenticatedAsync()
     .then(() => leagueStore.fetchLeagues())
-    .then(() => leagueStore.fetchFantasyLeagues())
+    .then(() => leagueStore.fetchFantasyLeagues(Number(route.params.id)))
     .then(() => {
       if (authStore.authenticated) {
         leagueStore.fetchFantasyDraftPoints()
       }
+
     });
 })
 
 watch(() => authStore.authenticated, () => {
   leagueStore.fetchLeagues()
-    .then(() => leagueStore.fetchFantasyLeagues())
+    .then(() => leagueStore.fetchFantasyLeagues(Number(route.params.id)))
     .then(() => leagueStore.fetchFantasyDraftPoints());
 })
 

--- a/frontend/vue3-web-app/src/components/Fantasy/FantasyNavbar.vue
+++ b/frontend/vue3-web-app/src/components/Fantasy/FantasyNavbar.vue
@@ -1,30 +1,13 @@
 <template>
   <div class="league-select bg-primary">
-    <v-container class="ma-0" style="height:2.4rem;max-width:600px">
-      <v-row>
-        <v-col style="max-width: 80px;" align-self="center">
-          <v-row class="pa-2 mb-1 league-selector-label" justify="end">
-            <span>League:</span>
-          </v-row>
-        </v-col>
-        <v-col>
-          <v-row>
-            <v-select label="League" v-model="leagueStore.selectedLeague" :items="leagueOptions" item-title="name"
-              @update:model-value="updateSelectedLeague" density="compact" single-line variant="underlined"
-              return-object>
-              <template v-slot:item="{ props, item }">
-                <v-list-item v-bind="props" class="league-selector" :title="item.raw.name"
-                  :variant="leagueStore.isLeagueActive(item.raw) ? 'text' : 'plain'">
-                  <template v-slot:append>
-                    <v-icon v-if="!leagueStore.isLeagueOpen(item.raw)" icon="fa-solid fa-lock" size="x-small"></v-icon>
-                  </template>
-                </v-list-item>
-              </template>
-            </v-select>
-          </v-row>
-        </v-col>
-      </v-row>
-    </v-container>
+    <v-tabs v-model="leagueStore.selectedLeague">
+      <v-tab v-for="league in leagueOptions" :value="league"
+        :variant="leagueStore.isLeagueActive(league) ? 'text' : 'plain'">
+        {{ league.name }}
+        <v-icon v-if="!leagueStore.isLeagueOpen(league)" class="ml-1" icon="fa-solid fa-lock" size="x-small">
+        </v-icon>
+      </v-tab>
+    </v-tabs>
   </div>
   <div class="bg-secondary">
     <v-tabs v-model="leagueStore.selectedFantasyLeague">
@@ -45,8 +28,9 @@
 import { computed, onMounted, watch } from 'vue';
 import { useFantasyLeagueStore } from '@/stores/fantasyLeague';
 import { useAuthStore } from '@/stores/auth';
-import { VContainer, VRow, VCol, VSelect, VListItem, VIcon, VTab, VTabs } from 'vuetify/components'
+import { VIcon, VTab, VTabs } from 'vuetify/components'
 import { useRoute } from 'vue-router';
+import router from '@/router';
 
 const authStore = useAuthStore()
 const leagueStore = useFantasyLeagueStore()
@@ -64,9 +48,10 @@ const fantasyLeagueOptions = computed(() => {
 })
 
 onMounted(() => {
-  authStore.checkAuthenticatedAsync()
+  router.isReady()
+    .then(() => authStore.checkAuthenticatedAsync())
     .then(() => leagueStore.fetchLeagues())
-    .then(() => leagueStore.fetchFantasyLeagues(Number(route.params.id)))
+    .then(() => leagueStore.fetchFantasyLeagues(Number(route.query.fantasyLeagueId)))
     .then(() => {
       if (authStore.authenticated) {
         leagueStore.fetchFantasyDraftPoints()
@@ -76,17 +61,30 @@ onMounted(() => {
 })
 
 watch(() => authStore.authenticated, () => {
-  leagueStore.fetchLeagues()
-    .then(() => leagueStore.fetchFantasyLeagues(Number(route.params.id)))
-    .then(() => leagueStore.fetchFantasyDraftPoints());
+  if (leagueStore.allLeagues.length != 0) {
+    // If mounted hasn't fetched leagues yet then ignore this first watch
+    leagueStore.fetchLeagues()
+      .then(() => leagueStore.fetchFantasyLeagues(Number(route.query.fantasyLeagueId)))
+      .then(() => leagueStore.fetchFantasyDraftPoints());
+  }
 })
 
-function updateSelectedLeague() {
-  if (authStore.authenticated) {
-    leagueStore.fetchFantasyDraftPoints()
+watch(() => leagueStore.selectedLeague, () => {
+  if (leagueStore.fantasyLeagues.length > 0) {
+    // Don't fire this if fantasyLeagues hasn't been loaded yet
+    leagueStore.selectedFantasyLeague = leagueStore.defaultFantasyLeague;
+    if (authStore.authenticated) {
+      leagueStore.fetchFantasyDraftPoints()
+    }
   }
-  leagueStore.selectedFantasyLeague = leagueStore.defaultFantasyLeague;
-}
+})
+
+watch(() => leagueStore.selectedFantasyLeague, () => {
+  router.push({
+    path: route.path,
+    query: { fantasyLeagueId: leagueStore.selectedFantasyLeague.id }
+  })
+})
 
 </script>
 

--- a/frontend/vue3-web-app/src/components/Fantasy/fantasyDraft.ts
+++ b/frontend/vue3-web-app/src/components/Fantasy/fantasyDraft.ts
@@ -181,12 +181,9 @@ export interface DraftPickPlayer {
 }
 
 const selectedPlayer = ref<FantasyPlayer>();
-
 const currentDraftSlotSelected = ref<number>(1);
-
 const fantasyDraftPicks = ref<FantasyPlayer[]>([]);
-
-const fantasyPlayersAvailable = ref<FantasyPlayer[]>([]);
+const fantasyPlayerPointsAvailable = ref<FantasyPlayerPoints[]>([]);
 
 export function serializeFantasyDraftToDraftPick(fantasyDraftPlayer: any) {
     return {
@@ -203,8 +200,8 @@ export function fantasyDraftState() {
         })
     }
 
-    const setFantasyPlayers = (fantasyPlayers: FantasyPlayer[]) => {
-        fantasyPlayersAvailable.value = fantasyPlayers;
+    const setFantasyPlayerPoints = (fantasyPlayerPoints: FantasyPlayerPoints[]) => {
+        fantasyPlayerPointsAvailable.value = fantasyPlayerPoints;
     }
 
     const setFantasyPlayer = (fantasyPlayer: FantasyPlayer) => {
@@ -242,8 +239,8 @@ export function fantasyDraftState() {
             acc[fp.teamId] = (acc[fp.teamId] || 0) + 1;
             return acc;
         }, {})
-        const maxTeamCheck = fantasyPlayersAvailable.value.filter(player => player.id == fantasyPlayer.id && (teamCounts[player.teamId] ?? 0) < 2).length == 0;
-        const minTeamsCheck = new Set(fantasyPlayersAvailable.value.flatMap(player => player.teamId)).size > 2;
+        const maxTeamCheck = fantasyPlayerPointsAvailable.value.filter(player => player.fantasyPlayer.id == fantasyPlayer.id && (teamCounts[player.fantasyPlayer.teamId] ?? 0) < 2).length == 0;
+        const minTeamsCheck = new Set(fantasyPlayerPointsAvailable.value.flatMap(player => player.fantasyPlayer.teamId)).size > 2;
         return pickedPlayer || !correctDraftSlotRoleSelected || (maxTeamCheck && minTeamsCheck);
     }
 
@@ -253,7 +250,7 @@ export function fantasyDraftState() {
             return acc;
         }, {})
         const maxTeamCheck = (teamCounts[teamId] ?? 0) >= 2;
-        const minTeamsCheck = new Set(fantasyPlayersAvailable.value.flatMap(player => player.teamId)).size > 2;
+        const minTeamsCheck = new Set(fantasyPlayerPointsAvailable.value.flatMap(player => player.fantasyPlayer.teamId)).size > 2;
         return maxTeamCheck && minTeamsCheck;
     }
 
@@ -261,9 +258,9 @@ export function fantasyDraftState() {
         selectedPlayer,
         currentDraftSlotSelected,
         fantasyDraftPicks,
-        fantasyPlayersAvailable,
+        fantasyPlayerPointsAvailable,
         setFantasyDraftPicks,
-        setFantasyPlayers,
+        setFantasyPlayerPoints,
         setFantasyPlayer,
         clearFantasyDraftPicks,
         disabledPlayer,

--- a/frontend/vue3-web-app/src/components/TheNavbar.vue
+++ b/frontend/vue3-web-app/src/components/TheNavbar.vue
@@ -13,7 +13,7 @@
         <LoginDiscord class="login-discord" />
     </div>
     <div>
-        <FantasyNavbar v-if="selectedTab === 1" />
+        <FantasyNavbar />
     </div>
 </template>
 

--- a/frontend/vue3-web-app/src/router/index.ts
+++ b/frontend/vue3-web-app/src/router/index.ts
@@ -24,7 +24,7 @@ const router = createRouter({
       component: () => import('../views/StatsView.vue')
     },
     {
-      path: '/fantasy',
+      path: '/fantasy/:id?',
       name: 'fantasy',
       component: () => import('../views/FantasyView.vue')
     },

--- a/frontend/vue3-web-app/src/router/index.ts
+++ b/frontend/vue3-web-app/src/router/index.ts
@@ -24,11 +24,10 @@ const router = createRouter({
       component: () => import('../views/StatsView.vue')
     },
     {
-      path: '/fantasy/:id?',
+      path: '/fantasy',
       name: 'fantasy',
       component: () => import('../views/FantasyView.vue')
     },
-
     {
       path: '/admin',
       name: 'admin',

--- a/frontend/vue3-web-app/src/stores/fantasyLeague.ts
+++ b/frontend/vue3-web-app/src/stores/fantasyLeague.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import type { FantasyLeague } from '@/types/FantasyLeague'
 import type { League } from '@/types/League'
 import { localApiService } from '@/services/localApiService'
-import type { FantasyDraftPoints, FantasyPlayer } from '@/components/Fantasy/fantasyDraft'
+import type { FantasyDraftPoints, FantasyPlayerPoints } from '@/components/Fantasy/fantasyDraft'
 
 export const useFantasyLeagueStore = defineStore({
   id: 'league',
@@ -24,7 +24,7 @@ export const useFantasyLeagueStore = defineStore({
       leagueEndTime: 0
     } as FantasyLeague,
     fantasyDraftPoints: [] as FantasyDraftPoints[],
-    fantasyPlayers: [] as FantasyPlayer[]
+    fantasyPlayerPoints: [] as FantasyPlayerPoints[]
   }),
 
   actions: {
@@ -54,7 +54,7 @@ export const useFantasyLeagueStore = defineStore({
           }
         })
         .then(() => {
-          this.fetchFantasyPlayers();
+          this.fetchFantasyPlayerPoints();
         })
     },
 
@@ -66,11 +66,11 @@ export const useFantasyLeagueStore = defineStore({
       }
     },
 
-    fetchFantasyPlayers() {
+    fetchFantasyPlayerPoints() {
       if (this.selectedFantasyLeague.id) {
-        return localApiService.getFantasyPlayers(this.selectedFantasyLeague.id)
+        return localApiService.getPlayerFantasyStats(this.selectedFantasyLeague.id)
           .then((result: any) => {
-            this.fantasyPlayers = result;
+            this.fantasyPlayerPoints = result;
           });
       }
     },

--- a/frontend/vue3-web-app/src/stores/fantasyLeague.ts
+++ b/frontend/vue3-web-app/src/stores/fantasyLeague.ts
@@ -35,12 +35,21 @@ export const useFantasyLeagueStore = defineStore({
       })
     },
 
-    fetchFantasyLeagues() {
+    fetchFantasyLeagues(selectFantasyLeagueId: number | undefined) {
       if (this.leagues.length == 0) this.fetchLeagues();
       return localApiService.getFantasyLeagues()
         .then((fantasyLeagueResult: any) => {
           this.setFantasyLeagues(fantasyLeagueResult);
-          if (this.selectedFantasyLeague.id == 0) {
+          if (selectFantasyLeagueId) {
+            let fantasyLeagueLookup = this.fantasyLeagues.find(fl => fl.id == selectFantasyLeagueId)
+            if (fantasyLeagueLookup) {
+              let leagueLookup = this.leagues.find(l => l.id == fantasyLeagueLookup.leagueId)
+              if (leagueLookup) {
+                this.setSelectedLeague(leagueLookup);
+                this.setSelectedFantasyLeague(fantasyLeagueLookup);
+              }
+            }
+          } else if (this.selectedFantasyLeague.id == 0) {
             this.setSelectedFantasyLeague(this.defaultFantasyLeague);
           }
         })

--- a/frontend/vue3-web-app/src/views/AboutView.vue
+++ b/frontend/vue3-web-app/src/views/AboutView.vue
@@ -13,8 +13,8 @@
         </p>
       </div>
       <div>
-        <v-data-table class="about-table" :items="statistics" :headers="statsHeaders" hide-default-footer
-          density="compact">
+        <v-data-table class="about-table" :items="statistics" :items-per-page="11" :headers="statsHeaders"
+          hide-default-footer density="compact">
           <template v-slot:item.value="{ item }">
             <span :style="getPointsPer(item)">{{ item.value }}</span>
           </template>
@@ -34,7 +34,7 @@ const statsHeaders = [
   {
     title: 'Name',
     value: 'name',
-    width: '40%'
+    width: '50%'
   },
   {
     title: 'Points Per',
@@ -44,7 +44,7 @@ const statsHeaders = [
   {
     title: 'Available?',
     value: 'available',
-    width: '30%'
+    width: '20%'
   },
 ];
 
@@ -57,6 +57,11 @@ const statistics = [
   {
     name: 'Death',
     value: '-0.3',
+    available: 'Yes'
+  },
+  {
+    name: 'Assist',
+    value: '0.15',
     available: 'Yes'
   },
   {
@@ -75,18 +80,28 @@ const statistics = [
     available: 'Yes'
   },
   {
-    name: 'Wards Planted',
+    name: 'Ward Planted',
     value: '0.15',
     available: 'Yes'
   },
   {
-    name: 'Camps Stacked',
+    name: 'Deward',
+    value: '0.15',
+    available: 'Yes'
+  },
+  {
+    name: 'Camp Stacked',
     value: '0.5',
     available: 'Yes'
   },
   {
-    name: 'Stuns',
-    value: '0.05',
+    name: 'Courier Kill',
+    value: '0.2',
+    available: 'Yes'
+  },
+  {
+    name: 'Stun Duration (sec)',
+    value: '0.025',
     available: 'Yes'
   },
   {

--- a/frontend/vue3-web-app/src/views/AdminView.vue
+++ b/frontend/vue3-web-app/src/views/AdminView.vue
@@ -308,13 +308,13 @@ const fantasyLeagueWeightDefaultItemSpecified = {
   tripleKillsWeight: 0,
   aegisSnatchedWeight: 0,
   rapiersPurchasedWeight: 0,
-  couriersKilledWeight: 0,
+  couriersKilledWeight: 0.2,
   networthRankWeight: 0,
   supportGoldSpentWeight: 0,
   observerWardsPlacedWeight: 0.15,
   sentryWardsPlacedWeight: 0,
-  wardsDewardedWeight: 0,
-  stunDurationWeight: 0.05
+  wardsDewardedWeight: 0.15,
+  stunDurationWeight: 0.025
 }
 
 const accountDefaultItemSpecified = {

--- a/frontend/vue3-web-app/src/views/FantasyView.vue
+++ b/frontend/vue3-web-app/src/views/FantasyView.vue
@@ -8,6 +8,7 @@
             <v-tab value="draft">Draft Players</v-tab>
             <v-tab value="leaderboard">Leaderboard</v-tab>
             <v-tab value="match">Fantasy Matches</v-tab>
+            <p>{{ $route.params.id }}</p>
           </v-tabs>
         </v-row>
         <v-row>

--- a/frontend/vue3-web-app/src/views/FantasyView.vue
+++ b/frontend/vue3-web-app/src/views/FantasyView.vue
@@ -8,7 +8,6 @@
             <v-tab value="draft">Draft Players</v-tab>
             <v-tab value="leaderboard">Leaderboard</v-tab>
             <v-tab value="match">Fantasy Matches</v-tab>
-            <p>{{ $route.params.id }}</p>
           </v-tabs>
         </v-row>
         <v-row>

--- a/frontend/vue3-web-app/src/views/FantasyView.vue
+++ b/frontend/vue3-web-app/src/views/FantasyView.vue
@@ -120,7 +120,7 @@ import { useFantasyDraftStore } from '@/stores/fantasyDraft';
 const authStore = useAuthStore();
 const leagueStore = useFantasyLeagueStore();
 const fantasyDraftStore = useFantasyDraftStore();
-const { fantasyDraftPicks, setFantasyDraftPicks, setFantasyPlayers, clearFantasyDraftPicks } = fantasyDraftState();
+const { fantasyDraftPicks, setFantasyDraftPicks, setFantasyPlayerPoints, clearFantasyDraftPicks } = fantasyDraftState();
 const draftFiltered = true;
 
 const showSuccessModal = ref(false);
@@ -177,7 +177,7 @@ const scrollAfterAlertDialog = () => {
 }
 
 onMounted(() => {
-  leagueStore.fetchFantasyPlayers()?.then(() => setFantasyPlayers(leagueStore.fantasyPlayers))
+  leagueStore.fetchFantasyPlayerPoints()?.then(() => setFantasyPlayerPoints(leagueStore.fantasyPlayerPoints))
   if (authStore.authenticated && leagueStore.selectedFantasyLeague) {
     fantasyDraftStore.fetchLeaderboard();
   } else if (!authStore.authenticated && leagueStore.selectedFantasyLeague) {
@@ -186,7 +186,7 @@ onMounted(() => {
 });
 
 watch(() => leagueStore.selectedFantasyLeague, () => {
-  leagueStore.fetchFantasyPlayers()?.then(() => setFantasyPlayers(leagueStore.fantasyPlayers))
+  leagueStore.fetchFantasyPlayerPoints()?.then(() => setFantasyPlayerPoints(leagueStore.fantasyPlayerPoints))
     .then(() => {
       if (authStore.authenticated) fantasyDraftStore.fetchLeaderboard()
     })

--- a/frontend/vue3-web-app/src/views/StatsView.vue
+++ b/frontend/vue3-web-app/src/views/StatsView.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/valid-v-slot -->
 <template>
   <v-container>
     <v-row>
@@ -9,20 +8,6 @@
             <v-tab value="league">League</v-tab>
             <v-tab value="match">Matches</v-tab>
           </v-tabs>
-        </v-row>
-      </v-col>
-      <v-col>
-        <v-row>
-          <v-select label="League" v-model="leagueStore.selectedFantasyLeague" :items="availableFantasyLeagues"
-            item-value="id" variant="underlined" return-object width="300">
-            <template v-slot:selection="{ item }" slot-scope="data">
-              <p>{{ fullFantasyName(item.raw.leagueId, item.raw.name) }}</p>
-            </template>
-            <template v-slot:item="{ props, item }">
-              <v-list-item v-bind="props" class="league-selector"
-                :title="fullFantasyName(item.raw.leagueId, item.raw.name)"></v-list-item>
-            </template>
-          </v-select>
         </v-row>
       </v-col>
     </v-row>
@@ -59,8 +44,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue';
-import { VContainer, VRow, VCol, VTabs, VTab, VTabsWindow, VTabsWindowItem, VListItem, VSelect } from 'vuetify/components';
+import { ref, onMounted } from 'vue';
+import { VContainer, VRow, VCol, VTabs, VTab, VTabsWindow, VTabsWindowItem } from 'vuetify/components';
 import { useFantasyLeagueStore } from '@/stores/fantasyLeague';
 import FantasyDataTable from '@/components/Stats/FantasyDataTable.vue';
 import LeagueDataTable from '@/components/Stats/LeagueDataTable.vue';
@@ -70,20 +55,11 @@ const statsTab = ref('fantasy')
 const leagueStore = useFantasyLeagueStore();
 const draftFiltered = false;
 
-const availableFantasyLeagues = computed(() => {
-  return leagueStore.activeFantasyLeagues
-})
-
 onMounted(() => {
   if (leagueStore.selectedFantasyLeague.id == 0) {
-    leagueStore.fetchFantasyLeagues()
+    leagueStore.fetchFantasyLeagues(undefined)
   }
 })
-
-function fullFantasyName(fantasyLeagueId: number, fantasyLeagueName: string) {
-  const league = leagueStore.activeLeagues.find(l => l.id === fantasyLeagueId);
-  return `${league?.name ?? ''} - ${fantasyLeagueName}`
-}
 
 </script>
 

--- a/webapi/data-access-library/Data/Fantasy/FantasyDraftRepository.cs
+++ b/webapi/data-access-library/Data/Fantasy/FantasyDraftRepository.cs
@@ -164,6 +164,7 @@ public class FantasyDraftRepository : IFantasyDraftRepository
             .ToListAsync();
 
         var fantasyDraftPoints = fantasyDraftPointsByLeagueQuery
+            .Where(fd => fd.DraftPickPlayers.Count > 0)
             .Select(fd => new FantasyDraftPointTotals
             {
                 FantasyDraft = fd,


### PR DESCRIPTION
Added some things that I hope improve the UI:

- Shared league selector across all pages, simplifying the store that populates leagues
- Added routing for the fantasy page so that whatever someone has selected, if they refresh it'll stay on that same page (this should probably be a refresh button on relevant pages though)
- Switched draft page to use mini draft pick cards to reuse components and be consistent
- Updated scoring to nerf stun duration (way too skewed) and instead value dewards and courier kills to help redistribute support fantasy points to more relevant stats